### PR TITLE
fix(terminal-server): bump session TTL to 90d and bind IPv6 dual-stack

### DIFF
--- a/dashboard/terminal-server/src/server.js
+++ b/dashboard/terminal-server/src/server.js
@@ -18,8 +18,9 @@ class TerminalServer {
     this.baseFolder = process.cwd();
     const ttlHours = Number(process.env.TERMINAL_SESSION_TTL_HOURS);
     const gcMinutes = Number(process.env.TERMINAL_SESSION_GC_INTERVAL_MINUTES);
+    // Default TTL bumped to 90 days; override via env TERMINAL_SESSION_TTL_HOURS if needed.
     this.sessionTtlMs = options.sessionTtlMs ?? (
-      Number.isFinite(ttlHours) && ttlHours > 0 ? ttlHours * 60 * 60 * 1000 : (24 * 60 * 60 * 1000)
+      Number.isFinite(ttlHours) && ttlHours > 0 ? ttlHours * 60 * 60 * 1000 : (90 * 24 * 60 * 60 * 1000)
     );
     this.sessionGcIntervalMs = options.sessionGcIntervalMs ?? (
       Number.isFinite(gcMinutes) && gcMinutes >= 0 ? gcMinutes * 60 * 1000 : (15 * 60 * 1000)
@@ -535,7 +536,7 @@ class TerminalServer {
     this.wss.on('connection', (ws, req) => this.handleWebSocketConnection(ws, req));
 
     return new Promise((resolve, reject) => {
-      server.listen(this.port, '0.0.0.0', (err) => {
+      server.listen(this.port, '::', (err) => {
         if (err) return reject(err);
         this.server = server;
         resolve(server);

--- a/dashboard/terminal-server/src/utils/session-store.js
+++ b/dashboard/terminal-server/src/utils/session-store.js
@@ -8,8 +8,9 @@ class SessionStore {
         // Store sessions in user's home directory
         this.storageDir = options.storageDir || path.join(os.homedir(), '.claude-code-web');
         this.sessionsFile = path.join(this.storageDir, 'sessions.json');
-        this.sessionTtlMs = options.sessionTtlMs ?? (24 * 60 * 60 * 1000);
-        this.maxFileAgeDays = options.maxFileAgeDays ?? 7;
+        // Default TTL bumped to 90 days to preserve long-running sessions.
+        this.sessionTtlMs = options.sessionTtlMs ?? (90 * 24 * 60 * 60 * 1000);
+        this.maxFileAgeDays = options.maxFileAgeDays ?? 90;
         fsSync.mkdirSync(this.storageDir, { recursive: true });
         this.initializeStorage();
     }


### PR DESCRIPTION
## Problem

Two independent issues with the terminal server causing session loss and connectivity failures:

1. **Sessions expiring nightly** — the default TTL of 24h caused all persisted sessions to be deleted every night, requiring users to restart their conversations daily
2. **IPv6 clients unable to connect** — binding on `0.0.0.0` (IPv4 only) drops connections from Tailscale and modern browsers that prefer IPv6

## Solution

**`dashboard/terminal-server/src/server.js`**
- Default TTL changed from `24h` to `90 days`; still overridable via `TERMINAL_SESSION_TTL_HOURS` env var
- `server.listen` bind address changed from `'0.0.0.0'` to `'::'` — IPv6 wildcard enables dual-stack, so IPv4 clients are still served via the OS dual-stack mapping

**`dashboard/terminal-server/src/utils/session-store.js`**
- `sessionTtlMs` default updated to match (90 days)
- `maxFileAgeDays` updated from 7 to 90 to stay consistent

## Test Plan

- [ ] Start terminal server, create a session, wait 25h — session still persists on restart
- [ ] Connect from an IPv6-only client (Tailscale endpoint) — connection succeeds
- [ ] `TERMINAL_SESSION_TTL_HOURS=1` env override still works — sessions expire in 1h

## Files Changed

| File | Change |
|------|--------|
| `dashboard/terminal-server/src/server.js` | TTL default 24h→90d, bind `'::'` |
| `dashboard/terminal-server/src/utils/session-store.js` | TTL + maxFileAgeDays 7→90 |

## Summary by Sourcery

Increase terminal session persistence and enable IPv6 dual-stack binding for the terminal server.

New Features:
- Allow the terminal server to accept connections over IPv6 while still supporting IPv4 via dual-stack binding.

Bug Fixes:
- Prevent unintended nightly expiration of terminal sessions by extending the default session TTL.

Enhancements:
- Extend default terminal session TTL and associated persisted session file retention to 90 days for longer-lived sessions.