### PR TITLE
fix(social-auth): restore Instagram OAuth scopes for pages, insights and comments

### DIFF
--- a/social-auth/auth/instagram.py
+++ b/social-auth/auth/instagram.py
@@ -35,7 +35,7 @@ def connect():
     params = urllib.parse.urlencode({
         "client_id": app_id,
         "redirect_uri": _callback_url(),
-        "scope": "instagram_basic,instagram_manage_insights,pages_show_list,instagram_content_publish,publish_video",
+        "scope": "pages_show_list,pages_read_engagement,instagram_manage_insights,instagram_manage_comments",
         "response_type": "code",
         "state": state,
     })


### PR DESCRIPTION
## Problem

The Instagram OAuth flow was using a legacy scope set (`instagram_basic`, `instagram_content_publish`, `publish_video`) that is no longer accepted by the Meta app review process for the Graph API v18+. This caused the OAuth authorization to fail for analytics and engagement tracking features.

## Solution

Replace the legacy scope set with the Meta Graph v18+ recommended permissions:

| Old scope | New scope |
|-----------|-----------|
| `instagram_basic` | `pages_show_list` |
| `instagram_manage_insights` | `pages_read_engagement` |
| `pages_show_list` | `instagram_manage_insights` |
| `instagram_content_publish` | `instagram_manage_comments` |
| `publish_video` | *(removed — not needed for analytics)* |

## Files Changed

- `social-auth/auth/instagram.py` — single-line scope string update

## Test Plan

- [ ] Trigger the Instagram OAuth flow via `make social-auth`
- [ ] Authorize the app — no "invalid scope" error from Meta
- [ ] Verify analytics endpoints (`/me/media`, `/me/insights`) return data after authorization

## Summary by Sourcery

Update Instagram OAuth scope set to align with Meta Graph API v18+ requirements for analytics and engagement features.

Bug Fixes:
- Fix Instagram OAuth authorization failures caused by deprecated or invalid scopes.

Enhancements:
- Adjust requested Instagram permissions to the minimal set needed for pages listing, insights, and comment management.