### PR TITLE
chore(config): add MercadoPago MCP integration and YouTube OAuth docs

### DIFF
--- a/.claude/rules/integrations.md
+++ b/.claude/rules/integrations.md
@@ -18,6 +18,7 @@
 | **Omie** | API | ERP — clients, invoices (NF-e), financials |
 | **Bling** | API (OAuth2 auto-refresh) | Brazilian ERP — products, orders, NF-e, contacts, stock. Run `make bling-auth` once to connect |
 | **Asaas** | API | Brazilian payments — Pix, boleto, credit card, subscriptions, marketplace split |
+| **MercadoPago** | MCP | Latin American payment gateway — 7 countries (Brazil, Argentina, Mexico, Chile, Colombia, Peru, Uruguay), payment links, QR codes, subscriptions, webhooks |
 | **YouTube** | API (OAuth) | Channel analytics |
 | **Instagram** | API (OAuth) | Profile analytics |
 | **LinkedIn** | API (OAuth) | Profile/org analytics |

--- a/.claude/skills/int-youtube/SKILL.md
+++ b/.claude/skills/int-youtube/SKILL.md
@@ -9,12 +9,58 @@ YouTube integration to monitor Evolution channels and others. Supports multiple 
 
 ## Setup
 
-Accounts configured via `make social-auth` (OAuth login) or manually in `.env`:
+### Conta Principal (autenticada via OAuth)
+
+Configurada via `.env` (gitignored):
+
+```env
+YOUTUBE_OAUTH_CLIENT_ID=<seu_client_id>.apps.googleusercontent.com
+YOUTUBE_OAUTH_CLIENT_SECRET=<seu_client_secret>
+YOUTUBE_REFRESH_TOKEN=<seu_refresh_token>
+```
+
+Scopes: `youtube`, `youtube.readonly`, `yt-analytics.readonly`, `yt-analytics-monetary.readonly`
+
+### Contas adicionais (SOCIAL_YOUTUBE_N_*)
+
+Configuráveis via `make social-auth` (OAuth login) ou manualmente no `.env`:
 ```env
 SOCIAL_YOUTUBE_1_LABEL=Evolution API
 SOCIAL_YOUTUBE_1_ACCESS_TOKEN=ya29...
 SOCIAL_YOUTUBE_1_CHANNEL_ID=UC9kZHm3TnEt41ztGOLyQO9g
 SOCIAL_YOUTUBE_1_REFRESH_TOKEN=1//0h...
+```
+
+### Auth Helper
+
+```python
+import os, urllib.request, urllib.parse, json
+
+def get_youtube_token() -> str:
+    data = urllib.parse.urlencode({
+        "client_id":     os.environ["YOUTUBE_OAUTH_CLIENT_ID"],
+        "client_secret": os.environ["YOUTUBE_OAUTH_CLIENT_SECRET"],
+        "refresh_token": os.environ["YOUTUBE_REFRESH_TOKEN"],
+        "grant_type":    "refresh_token",
+    }).encode()
+    req = urllib.request.Request(
+        "https://oauth2.googleapis.com/token", data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    return json.loads(urllib.request.urlopen(req).read())["access_token"]
+
+def ytapi(path: str) -> dict:
+    at = get_youtube_token()
+    req = urllib.request.Request(
+        f"https://www.googleapis.com/youtube/v3{path}",
+        headers={"Authorization": f"Bearer {at}"}
+    )
+    return json.loads(urllib.request.urlopen(req).read())
+
+# Canal próprio
+# ytapi("/channels?part=snippet,statistics&mine=true")
+# Últimos vídeos
+# ytapi("/search?part=snippet&forMine=true&type=video&order=date&maxResults=10")
 ```
 
 ## API Client

--- a/.mcp.json
+++ b/.mcp.json
@@ -35,6 +35,13 @@
     "intercom": {
       "type": "http",
       "url": "https://mcp.intercom.com/mcp"
+    },
+    "mercadopago": {
+      "type": "http",
+      "url": "https://mcp.mercadopago.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MERCADOPAGO_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Two documentation/configuration additions with no runtime code changes:

### 1. MercadoPago MCP Integration

Adds MercadoPago to the MCP server list in `.mcp.json` and documents it in the integrations index.

- **Coverage:** Brazil, Argentina, Mexico, Chile, Colombia, Peru, Uruguay
- **Auth:** `${MERCADOPAGO_TOKEN}` env var — token never committed, always comes from `.env`
- **Capabilities via MCP:** payment links, QR codes, subscriptions, webhook management

### 2. YouTube OAuth Documentation

Updates `.claude/skills/int-youtube/SKILL.md` to clarify how the primary YouTube account is configured:
- All credentials use `.env` placeholders (no real values in the file)
- Scopes documented: `youtube`, `youtube.readonly`, `yt-analytics.readonly`, `yt-analytics-monetary.readonly`
- Auth helper snippet included for token refresh

## Files Changed

| File | Change |
|------|--------|
| `.mcp.json` | Add `mercadopago` MCP server block |
| `.claude/rules/integrations.md` | Add MercadoPago row to integration table |
| `.claude/skills/int-youtube/SKILL.md` | Clarify OAuth auth setup; use env placeholder format |

## Notes

- No `Makefile` changes included — this PR is documentation/config only
- The `MERCADOPAGO_TOKEN` value lives exclusively in `.env` (gitignored)