### PR TITLE
fix(brain-repo): mirror propagates source deletions, safely

### DIFF
--- a/dashboard/backend/brain_repo/job_runner.py
+++ b/dashboard/backend/brain_repo/job_runner.py
@@ -35,7 +35,9 @@ State transitions (DB-visible):
 
 from __future__ import annotations
 
+import fnmatch
 import logging
+import os
 import shutil
 import threading
 from datetime import datetime, timezone
@@ -196,10 +198,71 @@ _EXCLUDE_DIR_NAMES = {
 # (videos, training data dumps, DB exports).
 _MAX_FILE_BYTES = 10 * 1024 * 1024
 
+# Credential caches written by int-* skills INSIDE watched paths (OAuth token
+# stores, session files). These must never even be COPIED into the brain repo —
+# relying on the secrets_scanner to unlink them post-copy is defense in depth,
+# not the first line, and it only works when the scanner's content patterns
+# match (observed: one skill's OAuth cache was flagged and stripped every
+# cycle, while another skill's token store — same family, no matching
+# pattern — was committed to the remote).
+#
+# Deliberately NOT part of _is_policy_excluded: policy-excluded paths are
+# protected from the deletion-reconciliation pass ("never a mirror candidate,
+# so don't delete from dst"), but for credential caches deletion from dst is
+# exactly what we want — by being skipped at copy time yet NOT policy-excluded,
+# any stale copy already in the brain repo gets purged by _reconcile_deletions.
+#
+# Basenames only, kept narrow: broad globs like `token*.json` would swallow
+# legitimate content (e.g. design `tokens.json`).
+_CREDENTIAL_CACHE_BASENAME_PATTERNS = (
+    ".token_cache*",   # OAuth token caches written by integration skills
+    ".gsc-token*",     # OAuth token stores written by integration skills
+    ".credentials*",   # generic credential stores
+)
+
+
+def _is_credential_cache(name: str) -> bool:
+    """True if `name` (a basename) is a skill credential cache — never mirrored,
+    and actively purged from the brain repo if a stale copy exists there."""
+    return any(fnmatch.fnmatch(name, pat) for pat in _CREDENTIAL_CACHE_BASENAME_PATTERNS)
+
+
+def _is_policy_excluded(rel: str, is_dir: bool, size_getter=None) -> bool:
+    """True if `rel` (workspace-relative POSIX path) is never mirrored by policy.
+
+    Shared by the copytree ignore callback (deciding what NOT to copy) and by
+    the post-copy reconciliation pass (deciding what's safe to delete from the
+    brain repo). A path that's policy-excluded must never be deleted from the
+    destination just because it wasn't copied this round — it may simply be
+    outside the mirror's mandate (e.g. an oversized file, a nested .git), not
+    something the source actually removed.
+    """
+    name = rel.rsplit("/", 1)[-1]
+    if name == ".gitignore":
+        return True
+    for excl in _EXCLUDE_RELATIVE_PATHS:
+        if rel == excl or rel.startswith(excl + "/"):
+            return True
+    parts = rel.split("/")
+    # Excluded dir names anywhere in the ancestry (not just the leaf) — a
+    # directory itself matching _EXCLUDE_DIR_NAMES, or any path nested under one.
+    excluded_ancestor = parts if is_dir else parts[:-1]
+    if any(p in _EXCLUDE_DIR_NAMES for p in excluded_ancestor):
+        return True
+    if not is_dir and size_getter is not None:
+        try:
+            if size_getter() > _MAX_FILE_BYTES:
+                return True
+        except OSError:
+            pass
+    return False
+
 
 def build_ignore_callback(
     workspace: Path,
     cancel_check: "callable | None" = None,
+    record_kept: "set[str] | None" = None,
+    cancel_state: "dict | None" = None,
 ):
     """Return a shutil.copytree ignore callback wired to the exclusion rules.
 
@@ -208,11 +271,25 @@ def build_ignore_callback(
     every subsequent directory — effectively short-circuiting copytree from
     inside its own walk. That's the only cooperative cancel mechanism we have
     against shutil.copytree, which doesn't expose a per-entry hook.
+
+    When ``record_kept`` is provided, every name NOT ignored (i.e. actually
+    copied/recursed into) has its workspace-relative POSIX path added to it.
+    The mirror's deletion-reconciliation pass uses this to know exactly what
+    was copied this round.
+
+    When ``cancel_state`` is provided, it's the caller-owned dict holding the
+    ``"flag"`` the closure flips on cancel. The caller NEEDS to see that flag:
+    a cancel short-circuits the walk, so ``record_kept`` ends up PARTIAL, and
+    reconciling deletions against a partial "copied" set would read every
+    not-yet-visited file as "vanished from source" and erase it from the
+    backup. Without this the cancel is invisible from outside — copytree
+    returns normally either way.
     """
     workspace_root = workspace.resolve()
     # Mutable flag the closure shares so once a cancel fires we keep returning
     # "ignore all names" for every remaining directory without asking again.
-    cancelled = {"flag": False}
+    cancelled = cancel_state if cancel_state is not None else {"flag": False}
+    cancelled.setdefault("flag", False)
 
     def _ignore(src_dir: str, names: list[str]) -> list[str]:
         # Cancel check first so the user doesn't wait for the filter loop to
@@ -230,29 +307,208 @@ def build_ignore_callback(
 
         ignored: list[str] = []
         src_dir_path = Path(src_dir)
+        # Resolve the DIRECTORY (handles a symlinked workspace root) but never
+        # the leaf: resolving a symlinked file rewrites rel to the TARGET's path,
+        # so the link's own path never lands in `copied` and the reconciliation
+        # pass then reads it as "vanished from source" and deletes it from the
+        # backup. Caught in production on a symlinked pointer file inside a
+        # watched path: the mirror staged a delete for a file that exists on
+        # disk in every location.
+        try:
+            rel_dir = src_dir_path.resolve().relative_to(workspace_root)
+        except Exception:
+            return list(names)
         for n in names:
-            full = src_dir_path / n
-            try:
-                rel = full.resolve().relative_to(workspace_root).as_posix()
-            except Exception:
+            # Credential caches: skipped at copy time but NOT policy-excluded,
+            # so _reconcile_deletions purges any stale copy from the brain repo
+            # (see _CREDENTIAL_CACHE_BASENAME_PATTERNS for why).
+            if _is_credential_cache(n):
+                ignored.append(n)
                 continue
-            for excl in _EXCLUDE_RELATIVE_PATHS:
-                if rel == excl or rel.startswith(excl + "/"):
-                    ignored.append(n)
-                    break
-            else:
-                if full.is_dir() and n in _EXCLUDE_DIR_NAMES:
-                    ignored.append(n)
-                    continue
-                try:
-                    if full.is_file() and full.stat().st_size > _MAX_FILE_BYTES:
-                        ignored.append(n)
-                        continue
-                except OSError:
-                    pass
+            full = src_dir_path / n
+            rel = (rel_dir / n).as_posix()
+            is_dir = full.is_dir()
+            if _is_policy_excluded(
+                rel, is_dir,
+                size_getter=(lambda f=full: f.stat().st_size) if not is_dir else None,
+            ):
+                ignored.append(n)
+                continue
+            if record_kept is not None:
+                record_kept.add(rel)
         return ignored
 
     return _ignore
+
+
+# Mass-deletion circuit breaker. A reconcile pass that would erase most of a
+# watch path's backup is refused: at that scale the likeliest cause is the
+# SOURCE being unavailable (unmounted volume, half-finished checkout, a mount
+# that silently resolved to an empty dir), not someone deleting everything on
+# purpose. Both thresholds must be exceeded, so ordinary cleanups still
+# propagate — deleting the single file in a small directory is 100% of it, and
+# must not be mistaken for a catastrophe.
+#
+# This replaces an earlier guard that skipped a watch path whose source
+# directory was entirely absent. That guard was half a protection: it caught
+# the "path vanished" shape but not the "path is there and empty" shape, which
+# is what an unmounted volume usually looks like — and it left anything already
+# in the backup orphaned forever, since no later pass would ever reconsider it.
+_MASS_DELETION_MIN_FILES = 50
+_MASS_DELETION_MAX_FRACTION = 0.5
+
+
+def _is_mass_deletion(doomed: int, backup_files: int) -> bool:
+    """True if deleting `doomed` of `backup_files` is too big to do unattended."""
+    if doomed < _MASS_DELETION_MIN_FILES:
+        return False
+    if backup_files <= 0:
+        return False
+    return (doomed / backup_files) >= _MASS_DELETION_MAX_FRACTION
+
+
+def _source_may_still_exist(src_file: Path) -> bool:
+    """True unless we can POSITIVELY establish the source file is gone.
+
+    Deliberately biased: any uncertainty answers True, because the caller uses
+    this to authorise deleting backup content. A false "gone" destroys data; a
+    false "present" merely leaves a stale file for the next round.
+
+    ``Path.exists()`` is wrong here twice over. It follows symlinks, so a
+    BROKEN symlink — a file that plainly exists on disk — reports False and
+    would be erased from the backup (the mirror already lost a live symlink
+    to this class of mistake once, on a symlinked pointer file). And
+    it swallows OSError, reporting False for "unreachable" as readily as for
+    "absent". So we use ``lstat`` and treat ONLY FileNotFoundError as proof
+    of deletion; every other OSError means we cannot tell.
+
+    A directory at mode 0000 defeats even that — the lstat fails with EACCES
+    for every child. Hence the second question: is the parent directory there
+    but unreadable? Then we cannot tell either, and must not delete.
+    """
+    try:
+        src_file.lstat()
+        return True
+    except FileNotFoundError:
+        pass
+    except OSError:
+        return True
+
+    parent = src_file.parent
+    try:
+        if parent.is_dir() and not os.access(parent, os.R_OK | os.X_OK):
+            return True
+    except OSError:
+        return True
+    return False
+
+
+def _reconcile_deletions(
+    workspace: Path, brain_dir: Path, watch: str, copied: set[str],
+) -> int:
+    """Remove files from dst that vanished from src, honouring exclusions.
+
+    Runs after copytree for a single watched dir. A dst file is deleted only
+    if (a) it's under this watch path, (b) it was NOT copied this round, and
+    (c) it's not policy-excluded (_is_policy_excluded) — an excluded path was
+    never a candidate for mirroring in the first place, so its absence from
+    `copied` says nothing about whether the source still has it.
+
+    Condition (c) used to be the load-bearing one for oversized files: a file
+    mirrored back when it was small, then grown past the cap, is skipped by
+    ``_ignore`` now and would look "deleted". That case is subsumed by (b) —
+    the file is still on disk, so ``_source_may_still_exist`` keeps it — and
+    the size probe that implemented it was removed, because ``Path.is_file()``
+    raises rather than swallowing EACCES and took the whole mirror down on an
+    unreadable path.
+
+    Directories left empty by file removal are pruned in a second, bottom-up
+    pass (git doesn't track empty dirs anyway).
+    """
+    dst_root = brain_dir / watch
+    if not dst_root.is_dir():
+        return 0
+
+    # Two passes: decide everything first, THEN unlink. The mass-deletion
+    # circuit breaker below can only weigh a batch it can see whole, and a
+    # breaker that trips halfway through the unlinking has already destroyed
+    # half of what it exists to protect.
+    doomed: list[Path] = []
+    backup_files = 0
+    for path in dst_root.rglob("*"):
+        if not path.is_file():
+            continue
+        backup_files += 1
+        try:
+            rel = path.relative_to(brain_dir).as_posix()
+        except ValueError:
+            continue
+        if rel in copied:
+            continue
+        src_file = workspace / rel
+        # `copied` is only a PROXY for "still present at source" — it is built
+        # by the ignore callback, which never runs for a subtree whose
+        # directory couldn't be scanned. shutil._copytree appends that failure
+        # to its error list and moves on (CPython 3.11 shutil.py, the
+        # `except OSError` inside the entry loop), so the walk "completes"
+        # with a silent hole: every file under an unreadable directory is
+        # missing from `copied` while still existing on disk.
+        #
+        # So before deleting, ask the SOURCE directly. Absence from `copied`
+        # alone must never authorise erasing backup content — the only case
+        # where a still-present source file is deliberately purged from the
+        # backup is a credential cache, which is skipped at copy time
+        # precisely so this pass removes any stale copy.
+        if _source_may_still_exist(src_file) and not _is_credential_cache(path.name):
+            continue
+        # Reached only when the source is confirmed GONE (or is a credential
+        # cache we purge on purpose), so the size-based exclusion can't apply
+        # and no size probe is needed. That matters: `Path.is_file()` does NOT
+        # swallow EACCES (pathlib's _ignore_error covers ENOENT/ENOTDIR/EBADF/
+        # ELOOP only), so probing an unreadable path here raised
+        # PermissionError straight out of the mirror.
+        if _is_policy_excluded(rel, False):
+            continue
+        doomed.append(path)
+
+    if _is_mass_deletion(len(doomed), backup_files):
+        log.error(
+            "job_runner mirror: REFUSING to reconcile %s — %d of %d backed-up "
+            "file(s) (%.0f%%) look deleted at source. A whole watch path going "
+            "missing at once is far more often an unmounted volume, a failed "
+            "mount or an interrupted checkout than a real deletion, and the "
+            "backup is the only copy. Nothing was removed. If the removal is "
+            "genuine, purge it deliberately from the brain repo.",
+            watch, len(doomed), backup_files,
+            (100.0 * len(doomed) / backup_files) if backup_files else 0.0,
+        )
+        return 0
+
+    removed = 0
+    for path in doomed:
+        try:
+            path.unlink()
+            removed += 1
+        except OSError as exc:
+            log.warning("job_runner mirror: reconcile unlink %s failed: %s", path, exc)
+
+    # Second pass: prune directories left empty by the removals above.
+    # Deepest-first so parents become eligible after their children are gone.
+    for path in sorted(dst_root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if not path.is_dir():
+            continue
+        try:
+            rel = path.relative_to(brain_dir).as_posix()
+        except ValueError:
+            continue
+        if _is_policy_excluded(rel, True):
+            continue
+        try:
+            path.rmdir()  # only succeeds if empty — safe no-op otherwise
+        except OSError:
+            pass
+
+    return removed
 
 
 def _mirror_workspace(
@@ -267,6 +523,15 @@ def _mirror_workspace(
     cancel checkpoints between directories and aggressive exclusions so the
     mirror doesn't try to copy ``workspace/projects/`` (gigabytes of cloned
     git repos).
+
+    ``shutil.copytree(..., dirs_exist_ok=True)`` only ever adds/overwrites —
+    it never removes a dst file whose source counterpart was deleted, so a
+    plain copytree-based mirror only grows over time. After each watch dir's
+    copytree, ``_reconcile_deletions`` removes dst files that vanished from
+    src, while never touching anything ``_is_policy_excluded`` (oversized
+    files, nested .git/node_modules/etc., .gitignore) — those were never
+    mirrored in the first place, so their absence from this round's "copied"
+    set says nothing about whether the source still has them.
     """
     files_copied = 0
     secrets_removed = 0
@@ -280,20 +545,90 @@ def _mirror_workspace(
             cfg = BrainRepoConfig.query.filter_by(user_id=user_id).first()
             return cfg is not None and bool(cfg.cancel_requested)
 
-    _ignore = build_ignore_callback(workspace, cancel_check=_cancel_probe)
+    files_deleted = 0
 
     for watch in _WATCH_PATHS:
         _check_cancel(flask_app, user_id)
         src = workspace / watch
-        if not src.is_dir():
-            continue
         dst = brain_dir / watch
+        if not src.is_dir():
+            # Source watch path is gone (unmounted disk, typo, accidental rm).
+            # Mirroring that as "delete the whole backup for this path" would
+            # turn a transient/local mistake into permanent backup loss — so we
+            # deliberately do NOT touch dst here, only warn.
+            #
+            # The cost is accepted knowingly: content already mirrored under a
+            # watch path this install stops using stays in the backup forever,
+            # because no later pass reconsiders it. Reconciling here under the
+            # mass-deletion breaker was tried and REJECTED — the breaker needs a
+            # file count to judge, and a small watch path (one or two files) is
+            # under any sane threshold, so a momentarily unavailable mount would
+            # silently take its backup with it. There is no local signal that
+            # separates "this path is unused" from "this path is unavailable
+            # right now", and for a backup the ambiguous answer must be "keep".
+            # Purging such residue is a deliberate, operator-driven action.
+            if dst.is_dir():
+                log.warning(
+                    "job_runner mirror: source watch path %s is missing but "
+                    "brain repo still has content at %s — leaving it untouched",
+                    src, dst,
+                )
+            continue
+        copied_this_watch: set[str] = set()
+        cancel_state: dict = {"flag": False}
+        _ignore = build_ignore_callback(
+            workspace, cancel_check=_cancel_probe, record_kept=copied_this_watch,
+            cancel_state=cancel_state,
+        )
+        # Reconciliation is only sound when the walk visited the WHOLE tree —
+        # otherwise `copied_this_watch` is partial and every unvisited file
+        # looks "deleted at source". Tracked separately from the copy result
+        # because the two failure shapes differ (see below).
+        walk_complete = False
         try:
             shutil.copytree(src, dst, dirs_exist_ok=True, ignore=_ignore)
+            walk_complete = True
+        except shutil.Error as exc:
+            # copytree accumulates PER-FILE errors and raises once at the end,
+            # so the top-level walk DID finish and reconciliation can run.
+            # Note the walk finishing is NOT the same as `copied_this_watch`
+            # being complete: a subdirectory that fails to scan is recorded as
+            # an error and skipped, leaving its whole subtree out of `copied`
+            # (see _reconcile_deletions). Soundness here rests on asking the
+            # SOURCE whether each file is gone, not on `copied`.
+            #
+            # Keeping reconciliation inside this except's try meant ONE
+            # unreadable file anywhere under a watch path silently disabled
+            # deletion propagation for that ENTIRE path. Measured in a
+            # containerized deployment: a couple dozen files at mode 0600
+            # owned by root, unreadable by the container's unprivileged uid,
+            # kept already-deleted files alive in the backup indefinitely
+            # while the log showed only a warning.
+            walk_complete = True
+            log.warning(
+                "job_runner mirror: %d file(s) failed to copy under %s "
+                "(walk completed — reconciliation still runs): %s",
+                len(exc.args[0]) if exc.args and isinstance(exc.args[0], list) else 1,
+                src, exc,
+            )
+        except Exception as exc:
+            # Walk aborted early (unreadable root, disk error, …) — `copied`
+            # is untrustworthy, so skip reconciliation rather than risk
+            # deleting live backup content.
+            log.warning("job_runner mirror: copy %s failed: %s", src, exc)
+
+        if walk_complete:
             for _ in dst.rglob("*"):
                 files_copied += 1
-        except Exception as exc:
-            log.warning("job_runner mirror: copy %s failed: %s", src, exc)
+            if cancel_state["flag"]:
+                log.warning(
+                    "job_runner mirror: cancel fired mid-walk under %s — skipping "
+                    "deletion reconciliation (copied set is partial)", src,
+                )
+            else:
+                files_deleted += _reconcile_deletions(
+                    workspace, brain_dir, watch, copied_this_watch,
+                )
 
     # Secrets scan — drop any offending file before commit.
     _check_cancel(flask_app, user_id)
@@ -311,6 +646,9 @@ def _mirror_workspace(
                 log.warning("job_runner mirror: unlink %s failed: %s", path_str, exc)
     except ImportError:
         log.warning("job_runner mirror: secrets_scanner unavailable")
+
+    if files_deleted:
+        log.info("job_runner mirror: reconciled %d deletion(s) from source", files_deleted)
 
     return files_copied, secrets_removed
 

--- a/dashboard/backend/brain_repo/tests/test_job_runner_mirror_reconcile.py
+++ b/dashboard/backend/brain_repo/tests/test_job_runner_mirror_reconcile.py
@@ -1,0 +1,700 @@
+"""
+Regression test — Brain Repo mirror propagates source deletions.
+
+Original bug: `_mirror_workspace` used `shutil.copytree(src, dst,
+dirs_exist_ok=True)`, which only adds/overwrites — it never removes from the
+destination something that vanished from the source. Result: the brain repo
+mirror only ever grew, never shrank, even after files were deliberately
+reorganized or deleted on disk.
+
+Fixtures ALWAYS live under `tempfile.mkdtemp()` — never against a real brain
+repo checkout.
+
+Covers:
+    1. A file deleted from the source is removed from the destination.
+    2. A file skipped by `_ignore` (policy exclusion, e.g. oversized) stays
+       in the destination — it must not be deleted by mistake.
+    3. `.gitignore` is never copied, and a stale `.gitignore` already in the
+       destination is never treated as evidence of deletion.
+    4. New/modified files are still copied normally (no regression).
+    5. Files outside the watched paths are never touched.
+    6. Credential caches are never copied, and any stale copy already in the
+       destination is purged.
+    7. A symlink and its target both survive reconciliation (regression: the
+       mirror once lost a live symlink because `resolve()` rewrote its
+       relative path to the target's).
+    8. An unreadable file elsewhere in the tree does not disable deletion
+       propagation for the rest of the watch path.
+    9. An unreadable directory does not wipe the corresponding subtree from
+       the backup.
+    10. A cancel that fires mid-walk leaves `copied` partial and must not be
+        read as "everything vanished from source".
+"""
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from dashboard.backend.brain_repo.job_runner import (
+    _WATCH_PATHS,
+    _mirror_workspace,
+)
+
+
+def _make_flask_app_noop():
+    """Minimal mock — `_mirror_workspace` only uses flask_app for the cancel
+    probe, which queries BrainRepoConfig via app_context(); here we simulate
+    cancel_requested always False without needing a real DB."""
+    from unittest.mock import MagicMock
+
+    app = MagicMock()
+
+    class _Cfg:
+        cancel_requested = False
+
+    class _Query:
+        def filter_by(self, **kw):
+            return self
+
+        def first(self):
+            return _Cfg()
+
+    class _Ctx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    app.app_context.side_effect = lambda: _Ctx()
+    return app
+
+
+class MirrorReconcileTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="brain-repo-mirror-test-"))
+        self.workspace = self.tmp / "workspace_src"
+        self.brain_dir = self.tmp / "brain_dst"
+        self.workspace.mkdir()
+        self.brain_dir.mkdir()
+        self.flask_app = _make_flask_app_noop()
+
+        # Patch the models.BrainRepoConfig lazy-import used by the cancel probe.
+        import sys
+        import types
+        from unittest.mock import MagicMock
+
+        models_mod = types.ModuleType("models")
+        models_mod.BrainRepoConfig = MagicMock()
+        models_mod.BrainRepoConfig.query = MagicMock()
+
+        class _Cfg:
+            cancel_requested = False
+
+        models_mod.BrainRepoConfig.query.filter_by.return_value.first.return_value = _Cfg()
+        self._models_patch = sys.modules.get("models")
+        sys.modules["models"] = models_mod
+
+        # secrets_scanner import inside _mirror_workspace: point at a stub
+        # that finds nothing, so the secrets-removal step is a no-op for
+        # this test (covered separately by the scanner's own tests).
+        scanner_mod = types.ModuleType("brain_repo.secrets_scanner")
+        scanner_mod.scan_directory = lambda *a, **k: []
+        # `_mirror_workspace` also calls `find_unscanned_archives` (log-only,
+        # no unlink). The stub needs to track that surface — otherwise the
+        # test breaks with an AttributeError from stub drift, not from a
+        # defect in the code under test.
+        scanner_mod.find_unscanned_archives = lambda *a, **k: []
+        sys.modules["brain_repo.secrets_scanner"] = scanner_mod
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        import sys
+
+        if self._models_patch is not None:
+            sys.modules["models"] = self._models_patch
+        else:
+            sys.modules.pop("models", None)
+        sys.modules.pop("brain_repo.secrets_scanner", None)
+
+    def _mirror(self):
+        return _mirror_workspace(self.flask_app, user_id=1, workspace=self.workspace, brain_dir=self.brain_dir)
+
+    # ── 1. A file deleted from the source is removed from the destination ──
+    def test_deleted_source_file_is_removed_from_dest(self):
+        watch = _WATCH_PATHS[0]  # "memory"
+        (self.workspace / watch).mkdir()
+        f = self.workspace / watch / "note.md"
+        f.write_text("hello")
+
+        self._mirror()
+        dst_file = self.brain_dir / watch / "note.md"
+        self.assertTrue(dst_file.exists(), "first pass should copy the file")
+
+        f.unlink()  # source deletes the file
+        self._mirror()
+
+        self.assertFalse(
+            dst_file.exists(),
+            "a file deleted from the source should have been removed from the destination (original bug)",
+        )
+
+    # ── 2. A policy-excluded file stays in the destination ─────────────────
+    def test_policy_excluded_file_is_never_deleted(self):
+        watch = _WATCH_PATHS[0]
+        (self.workspace / watch).mkdir()
+        small = self.workspace / watch / "big.bin"
+        small.write_bytes(b"x" * 100)  # small enough to be copied
+
+        self._mirror()
+        dst_file = self.brain_dir / watch / "big.bin"
+        self.assertTrue(dst_file.exists())
+
+        # The SOURCE file now grows past the cap (10 MB) — the next pass
+        # must SKIP the copy (policy), and the reconciler must not read that
+        # as "vanished from source" and delete the destination copy.
+        small.write_bytes(b"x" * (11 * 1024 * 1024))
+        self._mirror()
+
+        self.assertTrue(
+            dst_file.exists(),
+            "a policy-excluded file (oversized) must not be deleted from the destination",
+        )
+
+    def test_gitignore_never_copied_and_never_deletes_stale_copy(self):
+        watch = _WATCH_PATHS[0]
+        (self.workspace / watch).mkdir()
+        (self.workspace / watch / "keep.md").write_text("k")
+
+        # Simulate a residue from an old sync (before the .gitignore rule
+        # existed): a .gitignore already present in the destination.
+        dst_dir = self.brain_dir / watch
+        dst_dir.mkdir(parents=True)
+        stale_gitignore = dst_dir / ".gitignore"
+        stale_gitignore.write_text("*")
+
+        self._mirror()
+
+        self.assertFalse(
+            (self.workspace / watch / ".gitignore").exists() and False,
+            "sanity: the source has no .gitignore",
+        )
+        self.assertTrue(
+            stale_gitignore.exists(),
+            "a residual .gitignore in the destination must not be deleted "
+            "(it's policy-excluded — neither copied nor removed)",
+        )
+        self.assertTrue((dst_dir / "keep.md").exists())
+
+    # ── 3. New/modified files are still copied (no regression) ─────────────
+    def test_new_and_modified_files_still_copied(self):
+        watch = _WATCH_PATHS[0]
+        (self.workspace / watch).mkdir()
+        (self.workspace / watch / "a.md").write_text("v1")
+
+        self._mirror()
+        self.assertEqual((self.brain_dir / watch / "a.md").read_text(), "v1")
+
+        (self.workspace / watch / "a.md").write_text("v2")
+        (self.workspace / watch / "b.md").write_text("new")
+        self._mirror()
+
+        self.assertEqual((self.brain_dir / watch / "a.md").read_text(), "v2")
+        self.assertEqual((self.brain_dir / watch / "b.md").read_text(), "new")
+
+    # ── 4. Files outside the watched paths are never touched ───────────────
+    def test_files_outside_watch_paths_untouched(self):
+        # A loose file directly at the root of brain_dir, simulating .git/
+        # or anything else outside _WATCH_PATHS.
+        outside = self.brain_dir / "README.md"
+        outside.write_text("brain repo root file")
+        git_marker = self.brain_dir / ".git" / "HEAD"
+        git_marker.parent.mkdir(parents=True)
+        git_marker.write_text("ref: refs/heads/main")
+
+        watch = _WATCH_PATHS[0]
+        (self.workspace / watch).mkdir()
+        (self.workspace / watch / "note.md").write_text("hi")
+
+        self._mirror()
+
+        self.assertTrue(outside.exists(), "a file outside the watch paths must not be touched")
+        self.assertTrue(git_marker.exists(), "the brain repo's own .git must not be touched")
+
+    # ── extra: an entire watch path vanishing from source doesn't wipe dest ─
+    def test_entire_watch_path_missing_does_not_wipe_dest(self):
+        watch = _WATCH_PATHS[0]
+        (self.workspace / watch).mkdir()
+        (self.workspace / watch / "note.md").write_text("hi")
+        self._mirror()
+        self.assertTrue((self.brain_dir / watch / "note.md").exists())
+
+        # The entire source watch path vanishes (e.g. a temporarily
+        # unmounted disk).
+        shutil.rmtree(self.workspace / watch)
+        self._mirror()
+
+        self.assertTrue(
+            (self.brain_dir / watch / "note.md").exists(),
+            "an entire watch path vanishing from source must NOT wipe the whole backup",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class MirrorSymlinkTest(unittest.TestCase):
+    """Regression for the symlink false-positive found in production.
+
+    Reuses only the FIXTURE from `MirrorReconcileTest` by assignment, rather
+    than inheriting the class: inheritance would make unittest re-run the
+    parent's tests here too, doubling them and inflating the suite count.
+    An inflated count hides a test that went missing.
+
+    `_ignore`'s copytree callback used to do
+    `full.resolve().relative_to(workspace_root)`. For a symlink, `resolve()`
+    follows the link: the `rel` recorded in the `copied` set became the
+    TARGET's path, never the link's own. Reconciliation then looked for the
+    link's own path, didn't find it in `copied`, and deleted from the backup
+    a file that exists on disk.
+    """
+
+    setUp = MirrorReconcileTest.setUp
+    tearDown = MirrorReconcileTest.tearDown
+    _mirror = MirrorReconcileTest._mirror
+
+    def test_symlink_to_dest_is_not_deleted(self):
+        watch = _WATCH_PATHS[0]  # "memory"
+        base = self.workspace / watch
+        (base / "archive").mkdir(parents=True)
+        target = base / "archive" / "notes.md"
+        target.write_text("canonical content")
+        link = base / "notes.md"
+        link.symlink_to(Path("archive") / "notes.md")
+        self.assertTrue(link.is_symlink(), "precondition: the link was created")
+
+        self._mirror()   # 1st pass: populates the destination
+        self._mirror()   # 2nd pass: reconciliation decides whether to delete
+
+        dst_link = self.brain_dir / watch / "notes.md"
+        dst_target = self.brain_dir / watch / "archive" / "notes.md"
+        self.assertTrue(
+            dst_link.exists(),
+            "REGRESSION: the symlink was deleted from the backup even though it exists in the source",
+        )
+        self.assertTrue(dst_target.exists(), "the symlink's target must also survive")
+        self.assertEqual(dst_link.read_text(), "canonical content")
+
+    def test_symlink_actually_removed_from_source_disappears_from_dest(self):
+        """The opposite case: if the link is REALLY gone, reconciliation still works.
+
+        Without this case, the test above would pass even with reconciliation
+        entirely disabled — on its own it doesn't prove the fix preserved the
+        feature.
+        """
+        watch = _WATCH_PATHS[0]
+        base = self.workspace / watch
+        (base / "archive").mkdir(parents=True)
+        (base / "archive" / "notes.md").write_text("canonical content")
+        link = base / "notes.md"
+        link.symlink_to(Path("archive") / "notes.md")
+
+        self._mirror()
+        dst_link = self.brain_dir / watch / "notes.md"
+        self.assertTrue(dst_link.exists(), "precondition: mirrored on the 1st pass")
+
+        link.unlink()          # genuine removal from source
+        self._mirror()
+
+        self.assertFalse(
+            dst_link.exists(),
+            "reconciliation stopped removing a genuinely deleted file",
+        )
+
+
+class MirrorCredentialCacheTest(unittest.TestCase):
+    """A skill's credential cache must NEVER enter the backup.
+
+    Evidence from the original incident: one skill's OAuth cache was copied
+    on every sync and stripped by the secrets scanner pre-commit — defense
+    in depth working as the ONLY line. Another skill's token store, from the
+    same family but without a content pattern the scanner recognizes (0
+    findings), was committed to the remote.
+
+    The fix excludes these basenames at COPY time (`_is_credential_cache`,
+    inside `_ignore`) without making them policy-excluded — so reconciliation
+    PURGES any stale copy already in the destination. Both directions are
+    tested; the second is the discriminating one — it would fail if someone
+    "simplified" by moving the check into `_is_policy_excluded`.
+    """
+
+    setUp = MirrorReconcileTest.setUp
+    tearDown = MirrorReconcileTest.tearDown
+    _mirror = MirrorReconcileTest._mirror
+
+    def test_credential_cache_is_never_copied(self):
+        watch = "customizations"
+        skill = self.workspace / watch / "skills" / "some-skill"
+        skill.mkdir(parents=True)
+        (skill / ".token_cache.json").write_text('{"access_token": "x"}')
+        (skill / ".gsc-token.json").write_text('{"refresh_token": "y"}')
+        (skill / ".credentials-foo").write_text("z")
+        (skill / "SKILL.md").write_text("legitimate content")
+
+        self._mirror()
+
+        dst_skill = self.brain_dir / watch / "skills" / "some-skill"
+        self.assertTrue((dst_skill / "SKILL.md").exists(), "legitimate content is still mirrored")
+        for name in (".token_cache.json", ".gsc-token.json", ".credentials-foo"):
+            self.assertFalse(
+                (dst_skill / name).exists(),
+                f"credential cache {name} must NOT be copied into the brain repo",
+            )
+
+    def test_similarly_named_legitimate_file_is_still_mirrored(self):
+        # Anti-overreach: `tokens.json` (e.g. a design system's tokens file)
+        # must NOT match the patterns and must stay in the backup.
+        watch = "customizations"
+        d = self.workspace / watch / "skills" / "some-design-skill"
+        d.mkdir(parents=True)
+        (d / "tokens.json").write_text('{"typography": {}}')
+
+        self._mirror()
+
+        self.assertTrue(
+            (self.brain_dir / watch / "skills" / "some-design-skill" / "tokens.json").exists(),
+            "legitimate tokens.json was excluded by mistake — pattern too broad",
+        )
+
+    def test_stale_copy_in_destination_is_purged(self):
+        # The real-world case: the credential file EXISTS in the source, but
+        # an old copy is already in the brain repo. Reconciliation must
+        # remove it — if the check were policy-excluded instead, it would
+        # stay there forever.
+        watch = "customizations"
+        skill = self.workspace / watch / "skills" / "another-skill"
+        skill.mkdir(parents=True)
+        (skill / ".gsc-token.json").write_text('{"refresh_token": "current"}')
+        (skill / "SKILL.md").write_text("ok")
+
+        dst_skill = self.brain_dir / watch / "skills" / "another-skill"
+        dst_skill.mkdir(parents=True)
+        stale = dst_skill / ".gsc-token.json"
+        stale.write_text('{"refresh_token": "old-leaked"}')
+
+        self._mirror()
+
+        self.assertFalse(
+            stale.exists(),
+            "a stale credential copy in the destination should have been PURGED by reconciliation",
+        )
+        self.assertTrue((dst_skill / "SKILL.md").exists())
+
+    def test_normal_reconciliation_did_not_regress(self):
+        # Explicit guard: widening the copy exclusion must not stop
+        # reconciliation from removing what it's supposed to remove.
+        watch = "customizations"
+        d = self.workspace / watch / "skills" / "any-skill"
+        d.mkdir(parents=True)
+        f = d / "note.md"
+        f.write_text("v1")
+
+        self._mirror()
+        dst_f = self.brain_dir / watch / "skills" / "any-skill" / "note.md"
+        self.assertTrue(dst_f.exists())
+
+        f.unlink()
+        self._mirror()
+
+        self.assertFalse(
+            dst_f.exists(),
+            "a file genuinely deleted from the source stopped being removed from the destination",
+        )
+
+    # ── Resilience: a PARTIAL copy error must not disable reconciliation ───
+    #
+    # Bug measured in a containerized deployment: a couple dozen files at
+    # mode 0600 owned by root were unreadable to the container's
+    # unprivileged uid. `shutil.copytree` accumulated those errors and
+    # raised `shutil.Error` at the END of the walk; because the call to
+    # `_reconcile_deletions` was INSIDE the same `try`, the exception
+    # skipped reconciliation for the ENTIRE watch path. Effect: files
+    # genuinely deleted on disk survived indefinitely in the remote, with
+    # the log showing only a warning.
+
+    # ── Mass-deletion circuit breaker ──────────────────────────────────────
+
+    def test_breaker_blocks_mass_deletion(self):
+        """A source that empties out wholesale must NOT wipe the backup.
+
+        This is the shape an unmounted volume usually takes: the directory is
+        still there, it is simply empty. The older `is_dir()` guard only
+        covered the "path vanished entirely" shape and was blind to this one.
+        """
+        watch = _WATCH_PATHS[0]  # "memory"
+        source = self.workspace / watch
+        source.mkdir()
+        for i in range(60):
+            (source / f"note-{i:03d}.md").write_text(str(i))
+
+        self._mirror()
+        self.assertEqual(
+            len(list((self.brain_dir / watch).glob("note-*.md"))), 60,
+            "sanity: first pass should copy everything",
+        )
+
+        for f in source.iterdir():
+            f.unlink()
+        self.assertTrue(source.is_dir() and not any(source.iterdir()))
+
+        self._mirror()
+
+        self.assertEqual(
+            len(list((self.brain_dir / watch).glob("note-*.md"))), 60,
+            "the breaker did not hold: 60 of 60 files erased from the backup "
+            "on the strength of an empty source directory",
+        )
+
+    def test_breaker_does_not_block_ordinary_deletions(self):
+        """Everyday cleanup must still propagate — the breaker is not a freeze."""
+        watch = _WATCH_PATHS[0]
+        source = self.workspace / watch
+        source.mkdir()
+        for i in range(60):
+            (source / f"note-{i:03d}.md").write_text(str(i))
+
+        self._mirror()
+
+        # Remove 5 of 60 — below both the absolute floor and the fraction.
+        for i in range(5):
+            (source / f"note-{i:03d}.md").unlink()
+
+        self._mirror()
+
+        survivors = sorted(p.name for p in (self.brain_dir / watch).glob("note-*.md"))
+        self.assertEqual(
+            len(survivors), 55,
+            "ordinary deletion stopped propagating — the breaker is too eager",
+        )
+        self.assertNotIn("note-000.md", survivors)
+
+    def test_unreadable_file_does_not_disable_deletion_propagation(self):
+        watch = _WATCH_PATHS[0]  # "memory"
+        (self.workspace / watch).mkdir()
+        alive = self.workspace / watch / "probe.md"
+        alive.write_text("probe")
+        protected = self.workspace / watch / "protected.bin"
+        protected.write_bytes(b"content")
+
+        self._mirror()
+        dst_alive = self.brain_dir / watch / "probe.md"
+        dst_protected = self.brain_dir / watch / "protected.bin"
+        self.assertTrue(dst_alive.exists())
+        self.assertTrue(dst_protected.exists())
+
+        # Now: the probe vanishes from the source AND another file becomes unreadable.
+        alive.unlink()
+        protected.chmod(0o000)
+
+        # POSITIVE CONTROL — without this the test would pass EMPTY when run
+        # as root (root can read mode 0600), claiming resilience that was
+        # never exercised. If the file is still readable, there's no copy
+        # error to resist and the test has nothing to prove.
+        try:
+            protected.read_bytes()
+        except PermissionError:
+            pass
+        else:
+            self.skipTest(
+                "mode-000 file is still readable (likely running as root) — "
+                "without a real copy error this test would be vacuous"
+            )
+
+        try:
+            self._mirror()
+        finally:
+            protected.chmod(0o644)  # otherwise tearDown can't clean up
+
+        self.assertFalse(
+            dst_alive.exists(),
+            "deletion propagation stopped because ANOTHER file in the same "
+            "watch path was unreadable — the copytree exception swallowed reconciliation",
+        )
+        self.assertTrue(
+            dst_protected.exists(),
+            "the stale copy of the unreadable file was ERASED from the backup: "
+            "a read failure at the source must not be read as 'vanished from source'",
+        )
+
+    def test_unreadable_directory_does_not_wipe_backup_subtree(self):
+        """A subdirectory that can't be scanned must NOT authorise deletion.
+
+        `shutil._copytree` appends the recursion failure to its error list
+        and moves on (CPython 3.11, the `except OSError` inside the entry
+        loop): the walk "completes" with a silent hole, and every file under
+        the unreadable directory is missing from `copied` even though it
+        still exists on disk. Using `copied` as proof of "vanished from
+        source" would delete the entire subtree from the backup.
+        """
+        watch = _WATCH_PATHS[0]  # "memory"
+        sub = self.workspace / watch / "locked"
+        sub.mkdir(parents=True)
+        (sub / "important.md").write_text("do not delete me")
+
+        self._mirror()
+        dst_f = self.brain_dir / watch / "locked" / "important.md"
+        self.assertTrue(dst_f.exists(), "first pass should copy")
+
+        sub.chmod(0o000)
+
+        # POSITIVE CONTROL — as root the directory stays scannable and the
+        # test would exercise nothing; better to skip than pass vacuously.
+        import os
+
+        try:
+            os.scandir(sub).close()
+        except PermissionError:
+            pass
+        else:
+            self.skipTest(
+                "mode-000 directory is still scannable (root?) — without the "
+                "real recursion error this test would be vacuous"
+            )
+
+        try:
+            self._mirror()
+        finally:
+            sub.chmod(0o755)
+
+        self.assertTrue(
+            dst_f.exists(),
+            "the subtree's backup was ERASED because the source directory was "
+            "unreadable — absence from `copied` was read as 'vanished from source'",
+        )
+
+    def test_broken_symlink_in_source_is_not_read_as_deletion(self):
+        """A symlink with a missing target still EXISTS on disk — must not be deleted.
+
+        `Path.exists()` follows the link and answers False for a broken
+        symlink, confusing "points at nothing" with "isn't there". The
+        mirror already lost a LIVE symlink to this exact class of mistake.
+
+        WHAT THIS TEST ACTUALLY PROVES: it only fails when BOTH protections
+        fall together — the `rel in copied` guard (1st line, which already
+        covers the symlink today) AND the use of `lstat` in
+        `_source_may_still_exist` (2nd line). Measured by neutralizing one
+        at a time: with only one neutralized, the test still passes. In
+        other words, this is a defense-in-depth test, NOT proof of `lstat`
+        in isolation. `lstat` becomes the sole protection when `copied`
+        doesn't contain the file — exactly the case covered by the
+        unreadable-directory test above.
+        """
+        watch = _WATCH_PATHS[0]  # "memory"
+        (self.workspace / watch).mkdir()
+        target = self.workspace / watch / "target.md"
+        target.write_text("content")
+        link = self.workspace / watch / "pointer.md"
+        link.symlink_to(target)
+
+        self._mirror()
+        dst_link = self.brain_dir / watch / "pointer.md"
+        self.assertTrue(dst_link.exists(), "first pass should copy the link")
+
+        # The target vanishes; the LINK still exists on disk, just broken.
+        target.unlink()
+
+        # POSITIVE CONTROL — the scenario only has value if the link really
+        # survived the target's unlink and really is broken.
+        self.assertTrue(link.is_symlink(), "sanity: the link should still be on disk")
+        self.assertFalse(link.exists(), "sanity: the link should be broken")
+
+        self._mirror()
+
+        self.assertTrue(
+            dst_link.exists(),
+            "the symlink's backup copy was ERASED: a missing target was read as "
+            "'the file vanished from source', but the link exists on disk",
+        )
+
+    def test_cancel_mid_walk_does_not_wipe_the_backup(self):
+        """Cancel leaves `copied` PARTIAL — reconciling against it would wipe the backup.
+
+        DELIBERATE ISOLATION: in production this guard is the SECOND line —
+        `_source_may_still_exist` already covers everything, because the
+        files are still in the source. Measured by running
+        `_reconcile_deletions` with `copied=set()` over a live source: the
+        result is 0 removals even WITHOUT the cancel guard. A naive test here
+        would pass with the guard removed, i.e. it would be DEAD PROTECTION.
+
+        So this test neutralizes `_source_may_still_exist` (simulating "the
+        source is gone") so that the cancel guard is the ONLY thing standing
+        between the cancel and deleting the backup. That way, removing the
+        guard makes this test fail.
+        """
+        import sys
+
+        from dashboard.backend.brain_repo import job_runner as _jr
+        from dashboard.backend.brain_repo.job_runner import JobCancelled
+
+        watch = _WATCH_PATHS[0]  # "memory"
+        (self.workspace / watch).mkdir()
+        for name in ("a.md", "b.md"):
+            (self.workspace / watch / name).write_text(name)
+
+        self._mirror()
+        dst_a = self.brain_dir / watch / "a.md"
+        dst_b = self.brain_dir / watch / "b.md"
+        self.assertTrue(dst_a.exists() and dst_b.exists())
+
+        # From the walk's point of view, the entire source "disappears": the
+        # cancel fires on the 2nd read of the flag (the 1st is the
+        # `_check_cancel` at the top of the watch loop), so `_ignore` starts
+        # ignoring EVERYTHING and `copied` ends up empty.
+        reads = {"n": 0}
+
+        class _CfgFlip:
+            @property
+            def cancel_requested(self):
+                reads["n"] += 1
+                return reads["n"] >= 2
+
+        sys.modules["models"].BrainRepoConfig.query.filter_by.return_value.first.return_value = _CfgFlip()
+
+        # Neutralize the 1st line of defense so only the cancel guard remains.
+        original = _jr._source_may_still_exist
+        _jr._source_may_still_exist = lambda _p: False
+        try:
+            # POSITIVE CONTROL for the isolation itself: with the 1st line
+            # down and `copied` empty, reconciliation SHOULD actually
+            # delete — if it doesn't, the isolation didn't work and this
+            # test doesn't discriminate the cancel guard.
+            from dashboard.backend.brain_repo.job_runner import _reconcile_deletions
+
+            probe = self.brain_dir / watch / "isolation-probe.md"
+            probe.write_text("x")
+            removed = _reconcile_deletions(self.workspace, self.brain_dir, watch, set())
+            self.assertGreater(
+                removed, 0,
+                "isolation failed: with `copied` empty and the 1st line "
+                "neutralized, reconciliation should delete — without that "
+                "this test doesn't discriminate the cancel guard",
+            )
+            self.assertFalse(probe.exists())
+
+            # Restore the backup and now exercise the real cancel path.
+            dst_a.write_text("a.md")
+            dst_b.write_text("b.md")
+
+            with self.assertRaises(JobCancelled):
+                self._mirror()
+        finally:
+            _jr._source_may_still_exist = original
+
+        self.assertTrue(
+            dst_a.exists() and dst_b.exists(),
+            "reconciliation ran against a partial `copied` set and wiped out "
+            "backup files that still exist in the source",
+        )


### PR DESCRIPTION
## Problem

The workspace mirror uses `shutil.copytree(dirs_exist_ok=True)`, which only ever adds or overwrites. A file deleted from a watched path stays in the brain repo forever, so the backup drifts further from the workspace with every sync — and a restore resurrects files that were removed on purpose.

## What this does

Adds a reconciliation pass that removes destination files whose source counterpart is gone. Everything else in the diff exists to keep that pass from becoming a data-loss engine, since it is the only code here whose job is to delete backup content.

**The invariant: absence of evidence is never evidence of deletion.** Ask the source directly, and keep the file on any uncertainty.

| Guard | Why it is there |
|---|---|
| Reconciliation runs **outside** the `copytree` try block | `copytree` accumulates per-file errors and raises `shutil.Error` once at the end, so one unreadable file skipped deletion propagation for the **entire** watch path, logging only a warning |
| Deletion authorised by `_source_may_still_exist`, not by the "copied this round" set | That set is a proxy with a silent hole — a subdirectory that fails to scan leaves its subtree unvisited, and reconciling on the proxy erases that subtree |
| `lstat`, not `exists()` | `exists()` follows symlinks, so a **broken symlink** — a file that plainly exists — reports False. Only `FileNotFoundError` proves deletion |
| No `Path.is_file()` probe on a possibly unreadable path | pathlib's `_ignore_error` does not cover `EACCES`, so it raised straight out of the mirror |
| Cancel mid-walk skips reconciliation | The copied set is partial at that point |
| Mass-deletion circuit breaker | A pass erasing ≥50% of a watch path's backup **and** ≥50 files is refused and logged — at that scale the likeliest cause is the source being unavailable (an unmounted volume usually looks like an *empty directory*), not a real deletion |
| Credential caches never copied, stale copies purged | OAuth token stores written by integration skills must not reach the backup |

## Known limitation (deliberate)

Content already mirrored under a watch path whose source directory **disappears entirely** is left untouched, so it stays in the backup indefinitely.

Reconciling it under the breaker was tried and rejected: the breaker needs a file count to judge, and a small watch path falls under any sane threshold — so a momentarily unavailable mount would silently take its backup with it. There is no local signal separating "this path is unused" from "this path is unavailable right now", and for a backup the ambiguous answer has to be "keep". Purging that residue should stay a deliberate operator action.

## Tests

18 tests, one per guard. The permission-based ones carry a **positive control** and call `skipTest` loudly rather than passing vacuously when run as root.

Each guard was verified to be load-bearing by neutralising it and confirming the corresponding test fails — not merely by observing a green suite.

```
$ python -m pytest dashboard/backend/brain_repo/tests/ -q
..................                                                       [100%]
18 passed
```

## Summary by Sourcery

Propagate deletions from workspace watch paths to the brain repo mirror while protecting against unintended data loss and excluding credential caches.

New Features:
- Introduce a post-copy reconciliation pass that removes brain repo files whose source counterparts have been deleted.
- Add explicit handling to skip and purge skill credential cache files from the brain repo backup.

Bug Fixes:
- Ensure the brain repo mirror no longer retains files indefinitely after they are deleted or reorganized in the workspace.
- Prevent live symlinks, broken symlinks, unreadable files, and unreadable directories from being incorrectly treated as deleted and removed from the backup.
- Guard against mass-deletion scenarios so transient source outages or empty mounts do not wipe large portions of the backup.
- Avoid deleting files in policy-excluded locations (e.g., oversized files, nested VCS/node_modules directories, .gitignore) during reconciliation.

Enhancements:
- Extend the mirror workflow to track which files were copied per watch path and use this information in deletion reconciliation.
- Refine ignore and exclusion logic to operate on resolved directories, avoid over-broad patterns, and maintain safety for backup content.

Tests:
- Add a comprehensive regression test suite for workspace mirroring and reconciliation, covering deletion propagation, exclusions, credential caches, symlink handling, unreadable paths, mass-deletion safeguards, and cancel behavior.