### PR TITLE
fix(ADWs): routines that fail still exit 0 — scheduler logs them as success

### DIFF
--- a/ADWs/routines/backup.py
+++ b/ADWs/routines/backup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """ADW: Daily Backup — Export workspace gitignored data to local ZIP (+ S3 if configured)"""
 
+import sys
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from runner import run_script, banner, summary
@@ -41,9 +42,7 @@ def main():
     banner("💾 Daily Backup", "Workspace data export | systematic")
     results = []
     results.append(run_script(_do_backup, log_name="backup", timeout=300))
-    summary(results, "Daily Backup")
-
-
+    sys.exit(1 if summary(results, "Daily Backup") else 0)
 if __name__ == "__main__":
     try:
         main()

--- a/ADWs/routines/end_of_day.py
+++ b/ADWs/routines/end_of_day.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """ADW: End of Day — Consolidação do dia via Clawdia"""
 
+import sys
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from runner import run_skill, banner, summary
@@ -9,8 +10,7 @@ def main():
     banner("🌙 End of Day", "Memória • Logs • Tarefas • Aprendizados | @clawdia")
     results = []
     results.append(run_skill("prod-end-of-day", log_name="end-of-day", timeout=600, agent="clawdia-assistant", notify_telegram=True, daily_output_kind="eod"))
-    summary(results, "End of Day")
-
+    sys.exit(1 if summary(results, "End of Day") else 0)
 if __name__ == "__main__":
     try:
         main()

--- a/ADWs/routines/good_morning.py
+++ b/ADWs/routines/good_morning.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """ADW: Good Morning — Briefing matinal via Clawdia"""
 
+import sys
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from runner import run_skill, banner, summary
@@ -9,8 +10,7 @@ def main():
     banner("☀️  Good Morning", "Agenda • Emails • Tarefas | @clawdia")
     results = []
     results.append(run_skill("prod-good-morning", log_name="good-morning", timeout=600, agent="clawdia-assistant", notify_telegram=True, daily_output_kind="morning"))
-    summary(results, "Good Morning")
-
+    sys.exit(1 if summary(results, "Good Morning") else 0)
 if __name__ == "__main__":
     try:
         main()

--- a/ADWs/routines/memory_lint.py
+++ b/ADWs/routines/memory_lint.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """ADW: Memory Lint — Weekly health check on memory/ base via Clawdia"""
 
+import sys
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from runner import run_claude, banner, summary
@@ -37,8 +38,7 @@ def main():
     banner("🔍 Memory Lint", "Health check • Contradictions • Gaps • Stale data | @clawdia")
     results = []
     results.append(run_claude(PROMPT, log_name="memory-lint", timeout=600, agent="clawdia-assistant", daily_output_kind="memory-lint"))
-    summary(results, "Memory Lint")
-
+    sys.exit(1 if summary(results, "Memory Lint") else 0)
 if __name__ == "__main__":
     try:
         main()

--- a/ADWs/routines/memory_sync.py
+++ b/ADWs/routines/memory_sync.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """ADW: Memory Sync — Consolidates memory via Clawdia"""
 
+import sys
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from runner import run_claude, banner, summary
@@ -32,8 +33,7 @@ def main():
     banner("🧠 Memory Sync", "Logs • Meetings → Memory | @clawdia")
     results = []
     results.append(run_claude(PROMPT, log_name="memory-sync", timeout=600, agent="clawdia-assistant", daily_output_kind="memory-sync"))
-    summary(results, "Memory Sync")
-
+    sys.exit(1 if summary(results, "Memory Sync") else 0)
 if __name__ == "__main__":
     try:
         main()

--- a/ADWs/routines/weekly_review.py
+++ b/ADWs/routines/weekly_review.py
@@ -6,6 +6,7 @@ Usage:
     python weekly_review.py --team    # Agent Team (parallel, higher token cost)
 """
 
+import sys
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from runner import run_claude, banner, summary
@@ -51,7 +52,7 @@ def main():
         banner("📊 Weekly Review", "Meetings • Tasks • Agenda • Memory | @clawdia")
         results = [run_claude(PROMPT, log_name="weekly-review", timeout=900, agent="clawdia-assistant", daily_output_kind="weekly")]
 
-    summary(results, "Weekly Review" + (" (Team)" if use_team else ""))
+    sys.exit(1 if summary(results, "Weekly Review" + (" (Team)" if use_team else "")) else 0)
 
 if __name__ == "__main__":
     try:

--- a/ADWs/runner.py
+++ b/ADWs/runner.py
@@ -479,8 +479,12 @@ def banner(title: str, subtitle: str = "", color: str = "cyan"):
     console.print(Panel(content, border_style=color, padding=(0, 2)))
 
 
-def summary(results: list, title: str = "Completed"):
-    """Show final summary in terminal."""
+def summary(results: list, title: str = "Completed") -> int:
+    """Show final summary in terminal and RETURN the failure count.
+
+    Callers use the return value as an exit code. Without it every routine
+    exits 0 even when a step failed, so the scheduler logs success and the
+    failure alert never fires."""
     total_duration = sum(r.get("duration", 0) for r in results)
     success = sum(1 for r in results if r.get("success"))
     failed = len(results) - success
@@ -499,6 +503,8 @@ def summary(results: list, title: str = "Completed"):
         border_style="green" if failed == 0 else "yellow",
         padding=(0, 2)
     ))
+
+    return failed
 
 
 def send_telegram(text: str, chat_id: str = None) -> bool:

--- a/tests/test_routines_exit_code.py
+++ b/tests/test_routines_exit_code.py
@@ -1,0 +1,90 @@
+"""Regression: routines must exit non-zero when a step fails.
+
+The scheduler decides routine health by returncode (scheduler.py: run_adw).
+Before this fix, `runner.summary()` computed the failure count, printed
+"N failure(s)" and returned None — every routine exited 0 even on failure,
+so the scheduler logged a false success and never alerted.
+
+Two guards, two failure modes:
+1. `summary()` must RETURN the number of failed steps (fails if it goes
+   back to returning None).
+2. Every routine footer must PROPAGATE that value via sys.exit (fails if a
+   footer goes back to calling summary() as a bare statement).
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Routines shipped with the repo whose footer must propagate summary() -> exit code.
+CORE_ROUTINES = [
+    "ADWs/routines/backup.py",
+    "ADWs/routines/end_of_day.py",
+    "ADWs/routines/good_morning.py",
+    "ADWs/routines/memory_lint.py",
+    "ADWs/routines/memory_sync.py",
+    "ADWs/routines/weekly_review.py",
+]
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("adw_runner", REPO_ROOT / "ADWs" / "runner.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_summary_returns_failed_count():
+    runner = _load_runner()
+    ok = {"success": True, "duration": 1.0}
+    bad = {"success": False, "duration": 1.0}
+    assert runner.summary([ok, ok], "test") == 0
+    assert runner.summary([ok, bad], "test") == 1
+    assert runner.summary([bad, bad], "test") == 2
+
+
+def _summary_calls(tree: ast.AST):
+    """All Call nodes whose callee is `summary` (bare or attribute)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            name = fn.id if isinstance(fn, ast.Name) else getattr(fn, "attr", None)
+            if name == "summary":
+                yield node
+
+
+def _is_inside_sys_exit(tree: ast.AST, target: ast.Call) -> bool:
+    """True if `target` appears inside the arguments of a sys.exit(...) call."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        is_exit = (isinstance(fn, ast.Attribute) and fn.attr == "exit") or (
+            isinstance(fn, ast.Name) and fn.id in ("exit", "SystemExit")
+        )
+        if not is_exit:
+            continue
+        for arg in node.args:
+            if any(sub is target for sub in ast.walk(arg)):
+                return True
+    return False
+
+
+def test_routine_footers_propagate_summary_result():
+    offenders = []
+    for rel in CORE_ROUTINES:
+        path = REPO_ROOT / rel
+        tree = ast.parse(path.read_text(), filename=str(path))
+        calls = list(_summary_calls(tree))
+        assert calls, f"{rel}: expected at least one summary() call"
+        for call in calls:
+            if not _is_inside_sys_exit(tree, call):
+                offenders.append(f"{rel}:{call.lineno}")
+    assert not offenders, (
+        "summary() result discarded (routine would exit 0 on failure): "
+        + ", ".join(offenders)
+    )


### PR DESCRIPTION
## The defect

`ADWs/runner.py::summary(results, title)` computes `failed = len(results) - success`, prints `⚠ N failure(s)` — and returns nothing. Every core routine ends with a bare `summary(...)` call and no `sys.exit()`, so the process exits **0 regardless of outcome**.

The scheduler decides health by return code:

```python
status = "✓" if result.returncode == 0 else "✗"
```

and only a non-zero exit reaches the failure-alert path. So a routine whose only step failed is logged as `✓` and never alerts. That is an **active false green** — worse than no signal, because it reads as a healthy run.

Affected routines (all end in `summary()` with no exit): `good_morning.py`, `end_of_day.py`, `memory_sync.py`, `weekly_review.py`, `memory_lint.py`, `backup.py`.

## Reproduce

```
$ python3 ADWs/routines/good_morning.py     # with a failing step
  ✗ good-morning (0.2s | ...)
  ⚠ 1 failure(s)  Steps: 0/1
$ echo $?
0        # scheduler will log "✓ good-morning" and send no alert
```

## Impact, measured

On a live install with 61 days of run logs: under this change the daily routines would have exited non-zero on **1 of 23–28 runs per month each** (4 routines had exactly one failed run in the worst month; the rest zero).

So it surfaces roughly 1–4 real failures per month that are currently logged as successes, and it does **not** create alert noise — no routine shows chronic partial failure. That was checked before proposing, because a uniform `failed > 0 → exit 1` would be a bad trade if some routine failed partially by design.

## The fix

`summary()` returns `failed` (additive — no existing caller consumed the return value), and each footer becomes:

```python
sys.exit(1 if summary(results, "...") else 0)
```

Watchdog-style scripts that intentionally always exit 0 are untouched.

## Note on CI

`tests/test_routines_exit_code.py` is **not** picked up by the current workflow, which runs a named list of files under `tests/backend/`. Wiring it in would be a second, unrelated change, so it is deliberately left out — flagging it so the test is not assumed to be running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)