### PR TITLE
fix(scheduler): reload is unverifiable and unknown YAML sections vanish silently

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -175,6 +175,16 @@ def _load_routines_from_yaml(schedule, config_path: Path, is_plugin: bool = Fals
         # Determine slug for make-id derivation (only used for plugin routines)
         plugin_slug = config_path.parent.name if is_plugin else ""
 
+        # Sections outside this set are silently dropped: routines declared
+        # there never run and the operator gets no feedback at all.
+        _known_sections = {"daily", "weekly", "monthly"}
+        _unknown = [k for k in config if k not in _known_sections]
+        if _unknown:
+            print(f"  WARN: unread section(s) in {config_path.name}: "
+                  f"{', '.join(_unknown)} — the loader only reads "
+                  f"daily/weekly/monthly, so routines there will NEVER run",
+                  flush=True)
+
         for r in config.get("daily", []) or []:
             if not r.get("enabled", True):
                 continue
@@ -506,11 +516,11 @@ def main():
         if _reload_flag.is_set():
             _reload_flag.clear()
             ts = datetime.now().strftime("%H:%M:%S")
-            print(f"  {ts} [reload] SIGHUP received — clearing schedule and re-reading routines")
+            print(f"  {ts} [reload] SIGHUP received — clearing schedule and re-reading routines", flush=True)
             schedule.clear()
             setup_schedule()
             total = len(schedule.get_jobs())
-            print(f"  {ts} [reload] {total} routines scheduled")
+            print(f"  {ts} [reload] {total} routines scheduled", flush=True)
 
         schedule.run_pending()
         now = datetime.now()


### PR DESCRIPTION
Two independent bugs in `scheduler.py`, both the same shape: **the scheduler knows something the operator needs and drops it silently.**

## 1. SIGHUP reload is unverifiable

```python
print(f"  {ts} [reload] SIGHUP received — clearing schedule and re-reading routines")
print(f"  {ts} [reload] {total} routines scheduled")
```

No `flush=True`. Since stdout is normally redirected to a log file, Python uses block buffering and these lines sit in the buffer indefinitely — in practice `[reload]` **never appears in the log at all**.

The consequence is worse than a missing line. Someone checking *"did my config reload?"* sees nothing and cannot distinguish a working reload from a broken one. On our install this produced a real false conclusion in both directions: one person could not prove the reload had worked, and a second person read a pre-reload routine run as proof it had **failed**. The reload had worked all along; the evidence only surfaced when the process shut down and flushed its buffer.

The routine-execution print already passes `flush=True`. Only these two did not.

## 2. Unknown YAML sections vanish without a word

The loader reads exactly `daily`, `weekly`, `monthly`. Any other top-level key — a typo, or a section someone assumed was supported — is dropped **silently**: the routines under it simply never run. No error, no warning, nothing in the log.

We found a section that had been sitting unread for weeks with routines under it. Nothing in the system could have told us; it was found by reading the loader source.

Now the loader warns and names the offending sections. It does not add new sections or change what is read — it only stops the silence.

## Scope

Deliberately minimal: two bug fixes, no new features, no behaviour change beyond the two messages. Both are running on a live install.

Related but **not** included, since it would be a feature rather than a fix: the monthly loop is hardcoded to day 1 / hour 8 and ignores any per-routine scheduling key. Upstream never advertised such a key, so that is a separate discussion.

Also available as a follow-up if wanted: a boot-time check that every scheduled routine's script actually exists, shouting on startup instead of failing once per tick forever. It caught four separate incidents downstream where a routine had never run once. It is left out here because our implementation leans on downstream-only alerting infrastructure and would need adapting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify scheduler behavior when reloading and reading YAML configuration so operators receive explicit feedback instead of silent failures.

Bug Fixes:
- Ensure SIGHUP-triggered reload messages are flushed to logs so reload events and resulting job counts are reliably visible.
- Emit warnings for unknown top-level YAML sections so misconfigured or unsupported routine groups no longer disappear silently.