### PR TITLE
fix(hooks): agent-tracker never ran — reads a non-existent env var

### DIFF
--- a/.claude/hooks/agent-tracker.sh
+++ b/.claude/hooks/agent-tracker.sh
@@ -2,10 +2,13 @@
 # Agent Activity Tracker Hook
 # Writes active agent state to .claude/agent-status.json
 # Used by dashboard to show which agents are running in real-time
+#
+# The hook event arrives as argv[1] (configured in settings.json) and falls back
+# to the `hook_event_name` field of the JSON payload on stdin. Claude Code does
+# not export a CLAUDE_HOOK_EVENT environment variable.
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 STATUS_FILE="$PROJECT_DIR/.claude/agent-status.json"
-EVENT="$CLAUDE_HOOK_EVENT"
 
 # Initialize file if missing
 if [ ! -f "$STATUS_FILE" ]; then
@@ -13,45 +16,65 @@ if [ ! -f "$STATUS_FILE" ]; then
 fi
 
 NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+INPUT=$(cat)
+EVENT="${1:-}"
 
-if [ "$EVENT" = "PreToolUse" ]; then
-  # Read tool input from stdin
-  INPUT=$(cat)
-  TOOL=$(echo "$INPUT" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+# Fall back to the payload when the event is not passed as an argument.
+if [ -z "$EVENT" ]; then
+  EVENT=$(printf '%s' "$INPUT" | python3 -c \
+    "import sys,json;print(json.load(sys.stdin).get('hook_event_name',''))" 2>/dev/null)
+fi
 
-  if [ "$TOOL" = "Agent" ]; then
-    # Extract agent type from input
-    AGENT_TYPE=$(echo "$INPUT" | grep -o '"subagent_type":"[^"]*"' | head -1 | cut -d'"' -f4)
-    DESCRIPTION=$(echo "$INPUT" | grep -o '"description":"[^"]*"' | head -1 | cut -d'"' -f4)
-
-    if [ -z "$AGENT_TYPE" ]; then
-      AGENT_TYPE="general-purpose"
-    fi
-
-    # Add to active agents (simple append, dedupe on read)
-    python3 -c "
+if [ "$EVENT" = "PreToolUse" ] || [ "$EVENT" = "PostToolUse" ]; then
+  # Parse the payload with json, not grep: the real payload is pretty-printed
+  # ("tool_name": "Agent"), so a pattern anchored on `"tool_name":"` never matches.
+  # Passing values via argv also avoids breaking on quotes in the description.
+  printf '%s' "$INPUT" | python3 -c '
 import json, sys
+
+status_file, event, now = sys.argv[1], sys.argv[2], sys.argv[3]
+
 try:
-    with open('$STATUS_FILE') as f:
-        data = json.load(f)
-except:
-    data = {'active_agents': [], 'last_updated': ''}
+    payload = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
 
-data['active_agents'].append({
-    'agent': '$AGENT_TYPE',
-    'description': '$DESCRIPTION',
-    'started_at': '$NOW'
-})
-# Keep only last 20 entries
-data['active_agents'] = data['active_agents'][-20:]
-data['last_updated'] = '$NOW'
+if payload.get("tool_name") != "Agent":
+    sys.exit(0)
 
-with open('$STATUS_FILE', 'w') as f:
-    json.dump(data, f)
-" 2>/dev/null
-  fi
+tool_input = payload.get("tool_input") or {}
+agent = payload.get("subagent_type") or tool_input.get("subagent_type") or "general-purpose"
+description = payload.get("description") or tool_input.get("description") or ""
+
+try:
+    with open(status_file) as fh:
+        data = json.load(fh)
+except Exception:
+    data = {"active_agents": [], "last_updated": ""}
+
+active = data.get("active_agents") or []
+
+if event == "PreToolUse":
+    active.append({"agent": agent, "description": description, "started_at": now})
+else:
+    # PostToolUse: drop the most recent matching entry so the list reflects what
+    # is running now, instead of everything that ever started this session.
+    for i in range(len(active) - 1, -1, -1):
+        entry = active[i]
+        if entry.get("agent") == agent and entry.get("description") == description:
+            active.pop(i)
+            break
+
+data["active_agents"] = active[-20:]
+data["last_updated"] = now
+
+with open(status_file, "w") as fh:
+    json.dump(data, fh)
+' "$STATUS_FILE" "$EVENT" "$NOW"
 
 elif [ "$EVENT" = "Stop" ]; then
   # Clear active agents on session stop
   echo "{\"active_agents\":[],\"last_updated\":\"$NOW\"}" > "$STATUS_FILE"
 fi
+
+exit 0


### PR DESCRIPTION
The `agent-tracker.sh` hook reads the event from `$CLAUDE_HOOK_EVENT`, a variable Claude Code does not export. With `EVENT` empty, no branch ever executes — so the hook has never written a single entry, while being registered in `settings.json` and exiting 0 every time.

**Confirm in one command:**

```bash
rg CLAUDE_HOOK_EVENT
```

It appears only in the hook that reads it, never in anything that sets it.

**Proof by state:** `.claude/agent-status.json` stays at its initialization value, `{"active_agents":[],"last_updated":""}`. An empty `last_updated` means even the `Stop` branch — which only writes a timestamp — never ran.

This is hard to notice because three conditions stack: the hook always exits 0 (correct, per the hook contract), every internal call ends in `2>/dev/null`, and in our install nothing actually read `agent-status.json`, so the empty file never looked wrong.

### Three defects, each silent on its own

1. **The event source does not exist.** Fixed by reading `argv[1]` — the same pattern the plugin dispatcher already uses in `settings.json` — with a fallback to the `hook_event_name` field of the stdin payload.

2. **The payload parser could not match the real payload.** It used `grep -o` anchored on `"tool_name":"` — no space after the colon — while the actual payload is pretty-printed (`"tool_name": "Agent"`). Replaced with a json parse. This one was hidden behind the first: fixing only the env var would have left the hook silent.

3. **`$DESCRIPTION` was interpolated into a `python3 -c` string,** so a quote or apostrophe in the description broke the script — and `2>/dev/null` swallowed it. Values now go through argv.

### One behavior addition

Adds a `PostToolUse` branch. The hook previously only appended on start and cleared everything on `Stop`, so `active_agents` could never reflect what is *running* — only what had ever *started*. Since the stated purpose is to "show which agents are running in real-time", entries need to leave the list when an agent finishes.

Registering it requires one entry in `settings.json`:

```json
{
  "matcher": "Agent",
  "hooks": [{ "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-tracker.sh\" PostToolUse" }]
}
```

The fallback means existing registrations keep working unchanged — the event is then taken from the payload.

### Verification

Tested against: the real pretty-printed payload; the payload-only fallback (no argv); a non-`Agent` tool (must not record); malformed input (still exits 0, per contract); and `Stop`.

Control: ran the **previous** version with the same real payload — it writes nothing, leaving `last_updated` empty. That is the current behavior on `main`.

Found while auditing multi-agent orchestration in a downstream install. The same defect is present in any EvoNexus install with this hook registered.

## Summary by Sourcery

Fix the agent activity tracking hook so it correctly records agent lifecycle events and keeps the status file in sync with currently running agents.

New Features:
- Track agent completion via a new PostToolUse event so active_agents reflects agents that are currently running, not just those that have started.

Bug Fixes:
- Read the hook event from argv and JSON payload instead of a non-existent CLAUDE_HOOK_EVENT env var so the hook actually executes its branches.
- Parse the hook payload as JSON instead of via brittle grep patterns so pretty-printed payloads are correctly handled.
- Pass description and other dynamic values to the Python helper via argv to avoid breaking on quotes or special characters and silently failing.

Enhancements:
- Make the agent tracker more robust to malformed input and missing status files while maintaining a zero-exit behavior per the hook contract.